### PR TITLE
fix: 1.20.11 rendering crash

### DIFF
--- a/source/Animations/Items/Shape.cs
+++ b/source/Animations/Items/Shape.cs
@@ -336,7 +336,7 @@ internal class AnimatableShapeRenderer
 
         shaderProgram.UniformMatrices4x3(
             "elementTransforms",
-            GlobalConstants.MaxAnimatedElements,
+            elementTransforms.Count / 12,
             elementTransforms.ToArray()
         );
     }


### PR DESCRIPTION
This fixes the 1.20.11 ranged weapon rendering crash. It was caused by upstream changes in ClientAnimator having dynamically sized TransformationMatrices. This just changes FillShaderValues to not use the previously valid hardcoded `GlobalConstants.MaxAnimatedElements`