### PR TITLE
Fix Bow Crash in 1.20.11

### DIFF
--- a/source/Animations/Items/Shape.cs
+++ b/source/Animations/Items/Shape.cs
@@ -334,11 +334,10 @@ internal class AnimatableShapeRenderer
 
         ZeroTransformCorrection(elementTransforms);
 
-        shaderProgram.UniformMatrices4x3(
-            "elementTransforms",
-            GlobalConstants.MaxAnimatedElements,
-            elementTransforms.ToArray()
-        );
+        float[] elementTransformsArray = elementTransforms.ToArray();
+        int count = Int32.Min(elementTransformsArray.Length / (4 * 3), GlobalConstants.MaxAnimatedElements);
+
+        shaderProgram.UniformMatrices4x3("elementTransforms", count, elementTransformsArray);
     }
 
     private static void FillShaderValues(IShaderProgram shaderProgram, ItemRenderInfo itemStackRenderInfo, IRenderAPI render, ItemStack itemStack, Vec4f lightrgbs, Matrixf itemModelMatrix, IWorldAccessor world)


### PR DESCRIPTION
The "count" value in the UniformMatrices4x3 call seemed to be exceeding the length of the array given, which would sometimes cause an uncatchable invalid memory exception, leading to a CTD.

Passing the lower of the previous number and the actual number of transformation matrices in the array seems to have fixed it, at least in my testing.